### PR TITLE
reference type selection

### DIFF
--- a/src/components/profile_tree_input/ProfileTreeComponent.tsx
+++ b/src/components/profile_tree_input/ProfileTreeComponent.tsx
@@ -83,7 +83,6 @@ const ProfileTreeComponent: React.FC<ProfileTreeComponentProps> = (
       orderedConstraintResults,
     });
   }
-
   return (
     <div className="flex flex-col gap-4">
       <div className="flex flex-col mb-4 gap-2">

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -31,7 +31,6 @@ const Home = () => {
     setProfileTree(profile);
   };
 
-  console.log("profileTree", profileTree);
   return (
     <Layout>
       <div className="flex flex-col w-full pb-10 pt-4 overflow-scroll gap-2 px-8">


### PR DESCRIPTION
Implement Resource Type selection based on the target profiles specified in the respectives profiles structure definition.

E.g. Condition Subject type now only shows Patient and Group as Resources that can be selected.

Only works on the bindings specified for references. For more generic binding handling it might be neccessary to implement a general BindingResolver class. It seems that Bindings and their respective value sets can be defined on different levels:

e.g. reference type bindings in the profiles structure definition itself. Other valuesets, e.g. for codings that specify a snomed code scope, still need handling. Maybe an overview of how bindings can be defined, would a good idea. Gonna create a new issue for the purpose.